### PR TITLE
Add TCP server/client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
   apt:
     packages:
       - libboost-all-dev
+      - libasio-dev
 
 compiler:
   - gcc

--- a/src/connection.h
+++ b/src/connection.h
@@ -1,0 +1,160 @@
+#ifndef CONNECTION_H_
+#define CONNECTION_H_
+
+#include <iomanip>
+#include <string>
+#include <sstream>
+#include <vector>
+
+#include <boost/asio.hpp>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/bind.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/tuple/tuple.hpp>
+
+/// The Connection class provides serialization primitives on top of a socket.
+/**
+ * Each message sent using this class consists of:
+ * @li An 8-byte header containing the length of the serialized data in hexadecimal.
+ * @li The serialized data.
+ */
+class Connection
+{
+
+private:
+
+	boost::asio::ip::tcp::socket socket_;
+	enum { header_length = 8 };
+	std::string outbound_header_;
+	std::string outbound_data_;
+	char inbound_header_[header_length];
+	std::vector<char> inbound_data_;
+
+public:
+
+	Connection(boost::asio::io_service& io_service) :
+		socket_(io_service)
+	{
+		/* void */
+	}
+
+	/// get the underlying socket
+	boost::asio::ip::tcp::socket& socket()
+	{
+		return socket_;
+	}
+
+	/// asynchronously write a data structure to the socket
+	template <typename T, typename Handler>
+	void async_write(const T& t, Handler handler)
+	{
+		// serialize the data first so we know how large it is
+		std::ostringstream archive_stream;
+		boost::archive::text_oarchive archive(archive_stream);
+		archive << t;
+		outbound_data_ = archive_stream.str();
+
+		// format the header
+		std::ostringstream header_stream;
+		header_stream << std::setw(header_length)
+			<< std::hex
+			<< outbound_data_.size();
+		if (!header_stream || header_stream.str().size() != header_length)
+		{
+			// something went wrong, inform the caller
+			boost::system::error_code error(boost::asio::error::invalid_argument);
+			socket_.get_io_service().post(boost::bind(handler, error));
+			return;
+		}
+		outbound_header_ = header_stream.str();
+
+		// Write the serialized data to the socket. We use "gather-write" to send
+		// both the header and the data in a single write operation.
+		std::vector<boost::asio::const_buffer> buffers;
+		buffers.push_back(boost::asio::buffer(outbound_header_));
+		buffers.push_back(boost::asio::buffer(outbound_data_));
+		boost::asio::async_write(socket_, buffers, handler);
+	}
+
+	/// asynchronously read a data structure from the socket
+	template <typename T, typename Handler>
+	void async_read(T& t, Handler handler)
+	{
+		// issue a read operation to read exactly the number of bytes in a header
+		void (Connection::*f)(const boost::system::error_code&, T&, boost::tuple<Handler>)
+			= &Connection::handle_read_header<T, Handler>;
+		boost::asio::async_read(socket_,
+				boost::asio::buffer(inbound_header_),
+				boost::bind(f,
+					this, boost::asio::placeholders::error, boost::ref(t), boost::make_tuple(handler)));
+	}
+
+	/// handle a completed read of a message header
+	template <typename T, typename Handler>
+	void handle_read_header(const boost::system::error_code& e, T& t, boost::tuple<Handler> handler)
+	{
+		if (e)
+		{
+			boost::get<0>(handler)(e);
+		}
+		else
+		{
+			// determine the length of the serialized data
+			std::istringstream is(std::string(inbound_header_, header_length));
+			std::size_t inbound_data_size = 0;
+			if (!(is >> std::hex >> inbound_data_size))
+			{
+				// header doesn't seem to be valid. Inform the caller
+				boost::system::error_code error(boost::asio::error::invalid_argument);
+				boost::get<0>(handler)(error);
+				return;
+			}
+
+			// start an asynchronous call to receive the data
+			inbound_data_.resize(inbound_data_size);
+			void (Connection::*f)(const boost::system::error_code&, T&, boost::tuple<Handler>)
+				= &Connection::handle_read_data<T, Handler>;
+			boost::asio::async_read(socket_,
+					boost::asio::buffer(inbound_data_),
+					boost::bind(f,
+						this, boost::asio::placeholders::error, boost::ref(t), handler));
+		}
+	}
+
+	/// handle a completed read of message data
+	template <typename T, typename Handler>
+	void handle_read_data(const boost::system::error_code& e, T& t, boost::tuple<Handler> handler)
+	{
+		if (e)
+		{
+			boost::get<0>(handler)(e);
+		}
+		else
+		{
+			// extract the data structure from the data just received
+			try
+			{
+				std::string archive_data(&inbound_data_[0], inbound_data_.size());
+				std::istringstream archive_stream(archive_data);
+				boost::archive::text_iarchive archive(archive_stream);
+				archive >> t;
+			}
+			catch (std::exception& e)
+			{
+				// unable to decode data
+				boost::system::error_code error(boost::asio::error::invalid_argument);
+				boost::get<0>(handler)(error);
+				return;
+			}
+
+			// inform caller that data has been received ok
+			boost::get<0>(handler)(e);
+		}
+	}
+
+};
+
+typedef boost::shared_ptr<Connection> ConnectionPtr;
+
+#endif  // CONNECTION_H_

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 
-int main() {
+int main(int argc, char* argv[])
+{
 	std::cout << "Hello, sadDB!" << std::endl;
 }

--- a/src/tcp_client.h
+++ b/src/tcp_client.h
@@ -1,0 +1,63 @@
+#ifndef CLIENT_H_
+#define CLIENT_H_
+
+#include <iostream>
+#include <vector>
+
+#include <boost/asio.hpp>
+#include <boost/bind.hpp>
+#include "connection.h" // must come before boost/serialization headers
+#include <boost/serialization/vector.hpp>
+
+using boost::asio::io_service;
+using boost::asio::ip::tcp;
+
+template <typename T>
+class Client
+{
+
+private:
+
+	Connection conn;
+	T& object;
+
+public:
+
+	Client(T& object, io_service& ios, const std::string& host, const std::string& service) :
+		conn(ios),
+		object(object)
+	{
+		// resolve the host name into an IP address
+		tcp::resolver resolver(ios);
+		tcp::resolver::query query(host, service);
+		tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
+
+		// start an asynchronous connect operation
+		boost::asio::async_connect(conn.socket(),
+				endpoint_iterator,
+				boost::bind(&Client::handle_connect, this, boost::asio::placeholders::error));
+	}
+
+	/// handle completion of a connect operation
+	void handle_connect(const boost::system::error_code& e)
+	{
+		if (!e)
+		{
+			// successfully established connection, start writing
+			conn.async_write(object,
+					boost::bind(&Client::handle_write, this, boost::asio::placeholders::error));
+		}
+		else
+		{
+			std::cerr << e.message() << std::endl;
+		}
+	}
+
+	void handle_write(const boost::system::error_code& e)
+	{
+		/* void */
+	}
+
+};
+
+#endif  // CLIENT_H_

--- a/src/tcp_server.h
+++ b/src/tcp_server.h
@@ -1,0 +1,81 @@
+#ifndef SERVER_H_
+#define SERVER_H_
+
+#include <iostream>
+#include <memory>
+#include <vector>
+
+#include <boost/asio.hpp>
+#include <boost/asio/io_service.hpp>
+#include <boost/bind.hpp>
+#include <boost/thread.hpp>
+#include "connection.h" // must come before boost/serialization headers
+#include <boost/serialization/vector.hpp>
+
+using boost::asio::io_service;
+using boost::asio::ip::tcp;
+
+template <typename T>
+class Server
+{
+
+	io_service& ios;
+	tcp::acceptor acceptor;
+	std::vector<T>* collection;
+
+public:
+
+	Server(io_service& ios, unsigned short port) :
+		ios(ios),
+		acceptor(ios, tcp::endpoint(tcp::v4(), port))
+	{
+		collection = new std::vector<T>();
+
+		// start an accept operation for a new connection
+		ConnectionPtr new_conn(new Connection(acceptor.get_io_service()));
+		acceptor.async_accept(new_conn->socket(),
+				boost::bind(&Server::handle_accept, this, boost::asio::placeholders::error, new_conn));
+	}
+
+	~Server()
+	{
+		delete collection;
+	}
+
+	void handle_accept(const boost::system::error_code& e, ConnectionPtr conn)
+	{
+		if (!e)
+		{
+			// successfully established connection, start reading
+			boost::shared_ptr<T> t(new T());
+			conn->async_read(*t,
+					boost::bind(&Server::handle_read, this, boost::asio::placeholders::error, conn, t));
+		}
+
+		// start an accept operation for a new connection
+		ConnectionPtr new_conn(new Connection(acceptor.get_io_service()));
+		acceptor.async_accept(new_conn->socket(),
+				boost::bind(&Server::handle_accept, this, boost::asio::placeholders::error, new_conn));
+	}
+
+	/// handle completion of a read operation
+	void handle_read(const boost::system::error_code& e, ConnectionPtr conn, boost::shared_ptr<T> t)
+	{
+		if (!e)
+		{
+			collection->push_back(*t);
+		}
+		else
+		{
+			std::cerr << e.message() << std::endl;
+		}
+	}
+
+	T* get_collection()
+	{
+		return collection;
+	}
+
+};
+
+#endif  // SERVER_H_


### PR DESCRIPTION
Adds TCP server/client classes. Server listens on a port and waits for incoming serialized objects, which are deserialized and stored in a vector available through `get_collection()`. Clients connect to a server by specifying IP and port and can send a single object, automatically serialized beforehand.

Example usage is shown in commit cae4dfef6748a530c4a93ab4e8156a4c41ecfd67 (not part of this pullrequest).